### PR TITLE
added color support for 4.20in model

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -14,6 +14,7 @@ WaveshareEPaperTypeA = waveshare_epaper_ns.class_('WaveshareEPaperTypeA', Wavesh
 WaveshareEPaper2P7In = waveshare_epaper_ns.class_('WaveshareEPaper2P7In', WaveshareEPaper)
 WaveshareEPaper2P9InB = waveshare_epaper_ns.class_('WaveshareEPaper2P9InB', WaveshareEPaper)
 WaveshareEPaper4P2In = waveshare_epaper_ns.class_('WaveshareEPaper4P2In', WaveshareEPaper)
+WaveshareEPaper4P2InB = waveshare_epaper_ns.class_('WaveshareEPaper4P2InB', WaveshareEPaper)
 WaveshareEPaper5P8In = waveshare_epaper_ns.class_('WaveshareEPaper5P8In', WaveshareEPaper)
 WaveshareEPaper7P5In = waveshare_epaper_ns.class_('WaveshareEPaper7P5In', WaveshareEPaper)
 WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_('WaveshareEPaper7P5InV2', WaveshareEPaper)
@@ -32,6 +33,7 @@ MODELS = {
     '2.70in': ('b', WaveshareEPaper2P7In),
     '2.90in-b': ('b', WaveshareEPaper2P9InB),
     '4.20in': ('b', WaveshareEPaper4P2In),
+    '4.20in-b' : ('b', WaveshareEPaper4P2InB),
     '5.83in': ('b', WaveshareEPaper5P8In),
     '7.50in': ('b', WaveshareEPaper7P5In),
     '7.50inv2': ('b', WaveshareEPaper7P5InV2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -691,6 +691,61 @@ void WaveshareEPaper4P2In::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
+// ========================================================
+//               4.20in B/W/R Type B (LUT from OTP)
+// ========================================================
+void WaveshareEPaper4P2InB::initialize() {
+  // these exact timings are required for a proper reset/init
+  this->reset_pin_->digital_write(false);
+  delay(2);
+  this->reset_pin_->digital_write(true);
+  delay(200);  // NOLINT
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0f);  // LUT from OTP
+}
+
+void HOT WaveshareEPaper4P2InB::display() {
+  const int buffer_length = this->get_buffer_length_()/get_color_internal();
+  // COMMAND DATA START TRANSMISSION 1 (B/W data)
+  this->command(0x10);
+  this->start_data_();
+  this->write_array(this->buffer_, buffer_length);
+  this->end_data_();
+
+  // COMMAND DATA START TRANSMISSION 2 (RED data)
+  this->command(0x13);
+  this->start_data_();
+  this->write_array((this->buffer_+buffer_length), buffer_length);
+  this->end_data_();
+  App.feed_wdt();
+  delay(2);
+
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  // NOTE: power off < deep sleep
+  this->command(0x02);
+}
+int WaveshareEPaper4P2InB::get_width_internal() { return 400; }
+int WaveshareEPaper4P2InB::get_height_internal() { return 300; }
+void WaveshareEPaper4P2InB::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 4.2in (B)");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
 void WaveshareEPaper5P8In::initialize() {
   // COMMAND POWER SETTING
   this->command(0x01);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -116,6 +116,7 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
 enum WaveshareEPaperTypeBModel {
   WAVESHARE_EPAPER_2_7_IN = 0,
   WAVESHARE_EPAPER_4_2_IN,
+  WAVESHARE_EPAPER_4_2_IN_B,
   WAVESHARE_EPAPER_7_5_IN,
   WAVESHARE_EPAPER_7_5_INV2,
 };
@@ -195,6 +196,56 @@ class WaveshareEPaper4P2In : public WaveshareEPaper {
     // COMMAND DEEP SLEEP
     this->command(0x07);
     this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class WaveshareEPaper4P2InB : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND VCOM AND DATA INTERVAL SETTING
+    this->command(0x50);
+    this->data(0x17);  // border floating
+
+    // COMMAND VCM DC SETTING
+    this->command(0x82);
+    // COMMAND PANEL SETTING
+    this->command(0x00);
+
+    delay(100);  // NOLINT
+
+    // COMMAND POWER SETTING
+    this->command(0x01);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    delay(100);  // NOLINT
+
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+  int get_color_internal() override { return 2; }
+
+  uint8_t get_color_list_internal(uint8_t indexColor) override {
+    if(indexColor == 1) return display::ColorUtil::color_to_332(Color(255, 0, 0, 0));
+    return display::ColorUtil::color_to_332(display::COLOR_ON);
   }
 
  protected:


### PR DESCRIPTION
This commit adds red color support for the 4.20in model (version 1)

# What does this implement/fix? 

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/239

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
color:
  - id: COLOR_RED
    red: 100%
    green: 0%
    blue: 0%
    white: 0%

display:
  - platform: waveshare_epaper
    model: 4.20in-b
    id: epaper
    cs_pin: GPIO15
    dc_pin: GPIO4
    busy_pin: GPIO16
    reset_pin: GPIO5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
